### PR TITLE
drop urllib3 pin and add cachecontrol extra

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7386691ded52f7761109396316baf7058d30adc226cbd7bf07a7d6163f21c181
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -23,9 +23,9 @@ requirements:
     - python
     - pdm-backend
   run:
-    - urllib3 <2
     - pyproject_hooks
     - cachecontrol >=0.12.11
+    - filelock >=3.8.0
     - certifi
     - requests-toolbelt
     - rich >=12.3.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

v2.5.5 dropped the pin on urllib3 https://github.com/pdm-project/pdm/commit/d7143118717099ba8058658da8669e1e4daaa373